### PR TITLE
Standup

### DIFF
--- a/app/database.js
+++ b/app/database.js
@@ -81,7 +81,7 @@ const db = {
     });
   },
 
-  getMostRecentStandup(teamId) {
+  getMostRecentStandupRef(teamId) {
     return new Promise((resolve, reject) => {
       teamRef
         .child(teamId)
@@ -90,7 +90,9 @@ const db = {
         .once('value')
         .then((snapshot) => {
           if (snapshot.val()) {
-            return Object.keys(snapshot.val())[0];
+            return resolve(
+              `${teamId}/standups/${Object.keys(snapshot.val())[0]}`,
+            );
           } else {
             return reject(`No value for teams/${teamId}/standups.`);
           }
@@ -98,7 +100,9 @@ const db = {
     });
   },
 
-  saveStandupMessage(standupId, message) {},
+  saveStandupMessage(standupRef, message) {
+    teamRef.child(standupRef).child('responses').push(message.text);
+  },
 };
 
 export default db;

--- a/app/pmbot.js
+++ b/app/pmbot.js
@@ -17,13 +17,7 @@ const slack = new RtmClient(process.env.slack);
 slack.start();
 
 // Handles any incoming message from slack.
-slack.on(RTM_EVENTS.MESSAGE, (message) => {
-  // Debug line for us
-  if (message.user !== slack.activeUserId) {
-    console.log('Message:', message);
-  }
-
-  /*
+/*
   // Route message to appropriate handler
   // See types/subtypes: https://api.slack.com/events/message
   switch (message.subtype) {
@@ -37,21 +31,26 @@ slack.on(RTM_EVENTS.MESSAGE, (message) => {
       break;
   }
 */
+slack.on(RTM_EVENTS.MESSAGE, (message) => {
+  // not from me
+  if (!slackUtils.isFrom(slack.activeUserId, message)) {
+    console.log('Message:', message); // debug line
 
-  switch (slackUtils.messageType(message)) {
-    case MESSAGE_TYPE.DM:
-      handleDirectMessage(message);
-      break;
+    switch (slackUtils.messageType(message)) {
+      case MESSAGE_TYPE.DM:
+        handleDirectMessage(message);
+        break;
 
-    case MESSAGE_TYPE.CHANNEL:
-      handleChannelMessage(message);
-      break;
+      case MESSAGE_TYPE.CHANNEL:
+        handleChannelMessage(message);
+        break;
 
-    case MESSAGE_TYPE.GROUP:
-      break;
+      case MESSAGE_TYPE.GROUP:
+        break;
 
-    default:
-      break;
+      default:
+        break;
+    }
   }
 });
 
@@ -59,6 +58,7 @@ slack.on(RTM_EVENTS.MESSAGE, (message) => {
 
 function handleDirectMessage(message) {
   // TODO ignore message from self
+  console.log('STANDUP MESSAGE');
   standup.recieveStandup(message);
 }
 

--- a/app/slackUtils.js
+++ b/app/slackUtils.js
@@ -38,6 +38,10 @@ const slackUtils = {
     return MESSAGE_TYPE[MESSAGE_TYPE_RAW[message.channel[0]]];
   },
 
+  isFrom(userId, message) {
+    return message.user === userId;
+  },
+
   isMention(userId, string) {
     return string.indexOf(`<@${userId}>`) !== -1;
   },

--- a/app/standup.js
+++ b/app/standup.js
@@ -16,15 +16,14 @@ const standup = {
       });
   },
 
-  // TODO do something with remainingResponses
   recieveStandup(message) {
     db
       .getTeamForUser(message.user)
       .then((teamId) => {
-        return db.getMostRecentStandup(teamId);
+        return db.getMostRecentStandupRef(teamId);
       })
-      .then((standupId) => {
-        return db.saveStandupMessage(standupId, message);
+      .then((standupRef) => {
+        return db.saveStandupMessage(standupRef, message);
       })
       .catch((err) => {
         console.log(`recieveStandup Error: ${err}`);


### PR DESCRIPTION
start a standup with `@pmbot-dev standup` (existing)
messages all users (existing)
take message from user, find user (getTeamForUser) and find most recent standup (getMostRecentStandupRef) and then push message

TODO: update remaining responses. based on user... ugh we have to keep track of who's responded? maybe just table that for now
TODO: some error handling if there's no "most recent standup". maybe if the most recent one is too old?

adding TODOs as issues

![image](https://cloud.githubusercontent.com/assets/6548282/26517143/85cb5000-4260-11e7-90f6-adef3b74cf45.png)
